### PR TITLE
Wrong model specified for icetime

### DIFF
--- a/examples/picosoc/Makefile
+++ b/examples/picosoc/Makefile
@@ -10,7 +10,7 @@ hardware.asc: hardware.pcf hardware.blif
 	arachne-pnr -d 8k -P cm81 -o hardware.asc -p hardware.pcf hardware.blif
 
 hardware.bin: hardware.asc
-	icetime -d hx8k -c 12 -mtr hardware.rpt hardware.asc
+	icetime -d lp8k -c 12 -mtr hardware.rpt hardware.asc
 	icepack hardware.asc hardware.bin
 
 


### PR DESCRIPTION
The picosoc sample Makefile had the wrong model specified. It is also incorrect stated that the TinyFPGA BX uses an HX8K in GoJimmyPi's blog post
https://gojimmypi.blogspot.com/2019/01/risc-v-on-fpga-tinyfpga-via-wsl.html