### PR TITLE
Switching to nextpnr since arachne-pnr is deprecated.

### DIFF
--- a/examples/picosoc/Makefile
+++ b/examples/picosoc/Makefile
@@ -15,7 +15,7 @@ hardware.bin: hardware.asc
 
 
 firmware.elf: sections.lds start.S firmware.c 
-	riscv32-unknown-elf-gcc -march=rv32imc -nostartfiles -Wl,-Bstatic,-T,sections.lds,--strip-debug,-Map=firmware.map,--cref  -ffreestanding -nostdlib -o firmware.elf start.S firmware.c
+	riscv32-unknown-elf-gcc -march=rv32imc -mabi=ilp32 -nostartfiles -Wl,-Bstatic,-T,sections.lds,--strip-debug,-Map=firmware.map,--cref  -ffreestanding -nostdlib -o firmware.elf start.S firmware.c
 
 firmware.bin: firmware.elf
 	riscv32-unknown-elf-objcopy -O binary firmware.elf /dev/stdout > firmware.bin

--- a/examples/picosoc/Makefile
+++ b/examples/picosoc/Makefile
@@ -3,11 +3,11 @@ upload: hardware.bin firmware.bin
 	tinyprog -p hardware.bin -u firmware.bin
 
 
-hardware.blif: hardware.v spimemio.v simpleuart.v picosoc.v picorv32.v
-	yosys -ql hardware.log -p 'synth_ice40 -top hardware -blif hardware.blif' $^
+hardware.blif hardware.json &: hardware.v spimemio.v simpleuart.v picosoc.v picorv32.v
+	yosys -ql hardware.log -p 'synth_ice40 -top hardware -blif hardware.blif -json hardware.json' $^
 
-hardware.asc: hardware.pcf hardware.blif
-	arachne-pnr -d 8k -P cm81 -o hardware.asc -p hardware.pcf hardware.blif
+hardware.asc: hardware.pcf hardware.json
+	nextpnr-ice40 --lp8k --package cm81 --asc hardware.asc --pcf hardware.pcf --json hardware.json
 
 hardware.bin: hardware.asc
 	icetime -d hx8k -c 12 -mtr hardware.rpt hardware.asc

--- a/icestorm_template/Makefile
+++ b/icestorm_template/Makefile
@@ -21,11 +21,11 @@ DEVICE = lp8k
 
 all: $(PROJ).rpt $(PROJ).bin
 
-%.blif: %.v
-	yosys -p 'synth_ice40 -top $(PROJ) -blif $@' $<
+%.blif %.json : %.v
+	yosys -p 'synth_ice40 -top $(PROJ) -blif $@ -json $*.json' $<
 
-%.asc: $(PIN_DEF) %.blif
-	arachne-pnr -d 8k -P cm81 -o $@ -p $^
+%.asc: $(PIN_DEF) %.blif %.json
+	nextpnr-ice40 --$(DEVICE) --package cm81   --json $*.json --asc $@ --pcf  $(PIN_DEF)
 
 %.bin: %.asc
 	icepack $< $@
@@ -56,7 +56,7 @@ sudo-prog: $(PROJ).bin
 	sudo tinyprog -p $<
 
 clean:
-	rm -f $(PROJ).blif $(PROJ).asc $(PROJ).rpt $(PROJ).bin
+	rm -f $(PROJ).blif $(PROJ).asc $(PROJ).rpt $(PROJ).bin $(PROJ).json
 
 .SECONDARY:
 .PHONY: all prog clean


### PR DESCRIPTION
This builds the json file that nextpnr needs, and also switches to using nextpnr.
Issue #23