### PR TITLE
Move pin3_clk_16mhz to B2. Add user_led on B3.

### DIFF
--- a/icecube2_template/constraints/pins.pcf
+++ b/icecube2_template/constraints/pins.pcf
@@ -36,5 +36,6 @@ set_io pin24 A6
 set_io pin8 C1
 set_io pin17_ss F7
 set_io pin23 A7
-set_io pin3_clk_16mhz B4
+set_io pin3_clk_16mhz B2
+set_io user_led B3
 


### PR DESCRIPTION
Hi,

The pin3_clk_16mhz constraint for the icecube template seems to be on the wrong pin for TinyFPGA BX, moved to B2. Also added a constraint for the user LED.

Thanks,
Jacob